### PR TITLE
corrigido integração com Gravatar

### DIFF
--- a/theme/templates/archives.html
+++ b/theme/templates/archives.html
@@ -12,7 +12,9 @@
             {% for article in dates %}
                 <div class="archive-item">
                     <a href="{{ SITEURL }}/{{ article.author.url }}" title="See posts by {{ article.author }}">
+                    {% if article.author_gravatar %}
                         <img class="avatar" alt="{{ article.author }}" src="{{ article.author_gravatar }}">
+                    {% endif %}
                     </a>
                     <h5 class="archive-date">{{ article.date|strftime('%Y') }}</h5>
                     <h4 class="archive-date">{{ article.date|strftime('%d %B') }}</h4>

--- a/theme/templates/article.html
+++ b/theme/templates/article.html
@@ -31,7 +31,9 @@
         <header class="header-article">
             <hgroup>
                 <a href="{{ SITEURL }}/{{ article.author.url }}" title="See posts by {{ article.author }}">
-                    <img class="article-avatar" alt="{{ article.author }}" src="{{ article.author_gravatar }}">
+                    {% if article.author_gravatar %}
+                        <img class="article-avatar" alt="{{ article.author }}" src="{{ article.author_gravatar }}">
+                    {% endif %}
                 </a>
                 <h2 class="article-info">{{ article.author }}</h2>
                 <div>

--- a/theme/templates/post.html
+++ b/theme/templates/post.html
@@ -1,7 +1,9 @@
 <section class="post">
     <header class="post-header">
         <a href="{{ SITEURL }}/{{ article.author.url }}" title="See posts by {{ article.author }}">
-            <img class="avatar" alt="{{ article.author }}" src="{{ article.author_gravatar }}">
+            {% if article.author_gravatar %}
+                <img class="avatar" alt="{{ article.author }}" src="{{ article.author_gravatar }}">
+            {% endif %}
         </a>
         <h3><a class="post-title" href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h3>
             <p class="post-meta">{{ article.summary }}</p>


### PR DESCRIPTION
Corrigido Avatar. Se email informado não possuir uma conta vinculada ao gravatar, não incluir link para imagem no gravatar
