### PR TITLE
Ajustes CSS - Mostrar Imagens

### DIFF
--- a/theme/static/css/custom.css
+++ b/theme/static/css/custom.css
@@ -96,9 +96,6 @@ code {
   .tagline {
     margin-bottom: -20px;
   }
-  .section img {
-    display: none;
-  }
   .google-search {
     width: 100%;
   }
@@ -114,10 +111,6 @@ code {
   }
   .tagline {
     margin-bottom: -10px;
-  }
-  .section img {
-    display: none;
-    width: 30px;
   }
   .publish-github {
     display: none;


### PR DESCRIPTION
Essa correção faz com que as imagens sejam mostradas quando o display for menor que 768px.

@rg3915 @luzfcb Isso resolve o problema do issue #173 