### PR TITLE
Adicionado plugin customizado para mostrar posts randomicos.

### DIFF
--- a/custom-plugins/random_articles/Readme.md
+++ b/custom-plugins/random_articles/Readme.md
@@ -1,0 +1,28 @@
+Random Articles Plugin For Pelican
+========================
+
+This plugin insert a variable called `random_articles` in the page context.
+Only published articles are listed.
+
+
+Settings options:
+
+    RANDOM_ARTICLES = 3 # show only 3 random articles
+    SKIP_ARTICLES = 10 # skip 10 first articles before randomize
+
+
+Usage
+-----
+
+To change number of random articles, put on your settings:
+
+    RANDOM_ARTICLES = 3
+
+Then in some template you'll have a variable called `random_articles`.
+
+Ex:
+     {% for article in random_articles %}
+      <p  class="article-link tagline">
+        <a href="{{ SITEURL }}/{{ article.url}}">{{ article.title }}</a>
+      </p>
+     {% endfor %}

--- a/custom-plugins/random_articles/__init__.py
+++ b/custom-plugins/random_articles/__init__.py
@@ -1,0 +1,1 @@
+from .random_articles import *

--- a/custom-plugins/random_articles/random_articles.py
+++ b/custom-plugins/random_articles/random_articles.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import random
+
+from pelican import signals
+
+
+def is_published(article):
+    """ Return if article is published"""
+    return getattr(article, 'status', 'published') == 'published'
+
+
+def get_articles(generator):
+    skip_articles = generator.settings.get('SKIP_ARTICLES', 0)
+    articles = generator.context['articles']
+    return articles[skip_articles:]
+
+
+def register_articles(generator, metadata):
+    articles = filter(is_published, get_articles(generator))
+    articles_number = len(articles)
+
+    random_articles_number = generator.settings.get('RANDOM_ARTICLES', 3)
+
+    # we should return only articles number that exists
+    sample_number = random_articles_number
+    if articles_number < random_articles_number:
+        sample_number = articles_number
+
+    random_articles = random.sample(articles, sample_number)
+    generator.context['random_articles'] = random_articles
+
+
+def register():
+    signals.page_generator_context.connect(register_articles)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
 import os
+
+
 BASE = os.path.dirname(__file__)
 
 AUTHOR = u'PythonClub'
@@ -54,18 +56,23 @@ EXTRA_PATH_METADATA = {
 
 # Plugins
 PLUGIN_PATHS = [
-    'pelican-plugins'
+    'pelican-plugins',
+    'custom-plugins'
 ]
 
 PLUGINS = [
     'gravatar',
     'sitemap',
-    'pelican_youtube', # funciona somente com arquivos rst
-    'pelican_vimeo', # funciona somente com arquivos rst
-    'gzip_cache', # deve ser o ultimo plugin
+    'pelican_youtube',  # funciona somente com arquivos rst
+    'pelican_vimeo',  # funciona somente com arquivos rst
+    'random_articles',
+    'gzip_cache'  # deve ser o ultimo plugin
     # 'pdf', # funciona somente com arquivos rst
 
 ]
+
+RANDOM_ARTICLES = 10
+SKIP_ARTICLES = 10
 
 
 SITEMAP = {

--- a/theme/static/css/custom.css
+++ b/theme/static/css/custom.css
@@ -85,6 +85,16 @@ code {
   width: 80%;
 }
 
+.articles-random {
+  font-size: 0.8em;
+}
+
+.article-link {
+  margin-top: 0px;
+  line-height: 1em;
+}
+
+
 @media (max-width: 767px) {
   .brand-main a img {
     display: inline;
@@ -99,6 +109,12 @@ code {
   .google-search {
     width: 100%;
   }
+
+  .articles-random, .articles-link {
+    display: none;
+  }
+
+
 }
 
 @media (max-width: 480px) {

--- a/theme/templates/sidebar.html
+++ b/theme/templates/sidebar.html
@@ -8,6 +8,17 @@
           {% for title, link in MENUITEMS %}
           <p class="links"><a href="{{ SITEURL }}/{{ link }}">{{ title }}</a></p>
           {% endfor %}
+
+          <div class="section articles-random">
+            <h1 class="tagline">Não deixe de ver!</h1>
+
+              {% for article in random_articles %}
+                  <p  class="article-link tagline">
+                    <a href="{{ SITEURL }}/{{ article.url}}">{{ article.title }}</a>
+                  </p>
+              {% endfor %}
+          </div>
+
           <p class="social">
             {% for title, link in SOCIAL %}
             <a href="{{ link }}">
@@ -15,15 +26,6 @@
             </a>
             {% endfor %}
           </p>
-          <div class="section">
-            <span><a href="http://2014.pythonbrasil.org.br/">#Python2014, vamos?!</a></span>
-            <div class="section-body">
-              <a href="http://2014.pythonbrasil.org.br/" >
-                <img src="https://pybr.s3.amazonaws.com/static/images/badges/badge-pt-br.2ab99f7699bf.png"
-                width="250" height="276" alt="Eu vou na PythonBrasil[10]"/>
-              </a>
-            </div>
-          </div>
           <p class="tagline">
              Esta comunidade é signatária do
              <a target="_blank" href="http://smallactsmanifesto.org" title="Small Acts Manifesto">


### PR DESCRIPTION
Esse pull-request tem como objetivo melhorar a visualização dos artigos antigos #162.

Fiz um plugin que mostra o número de arquivos genericos de forma randomica, o único problema é que os artigos ainda não são atualizados toda vez que a página é carregada, mas vou resolver isso =)

 
