### PR TITLE
adicionando break-word em .content para corrigir width estourado

### DIFF
--- a/theme/static/css/pure.css
+++ b/theme/static/css/pure.css
@@ -308,6 +308,7 @@ pre {
     .content {
         padding: 1em 1.5em 0;
         font-size: 85%;
+        word-wrap: break-word;
     }
 
     .cover-img {


### PR DESCRIPTION
Devido a alguns links grandes o width em mobile estava estourando, e atrapalhando a navegação. 
![pyclb1](https://cloud.githubusercontent.com/assets/3240670/10764056/91a94306-7cb3-11e5-93cc-59011e0ebe8d.png)

Adicionei uma linha no css para forçar a quebra de linha em qualquer link que seja capaz de estourar o width. Tornando a responsividade mais segura.

![pyclb2](https://cloud.githubusercontent.com/assets/3240670/10764105/c6df0c2c-7cb3-11e5-82da-60aa5b9b3048.png)


