### PR TITLE
Configura Actions para testar build de novos artigos e publicar no GitHub Pages

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,32 @@
+name: Build Test
+
+on:
+  push:
+    branches:
+      - '*'
+      - '!pelican'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout do repositório
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      
+      - name: Configura python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "2.7"
+          cache: pip
+      
+      - name: Instala dependências
+        run: pip install -r requirements.txt
+
+      - name: Build do site
+        run: make publish

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,55 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - pelican
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout do repositório
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      
+      - name: Configura python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "2.7"
+          cache: pip
+      
+      - name: Instala dependências
+        run: pip install -r requirements.txt
+
+      - name: Build do site
+        run: make publish
+
+      - name: Upload do site
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: output/
+
+  deploy:
+    name: Deploy
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy no GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Esse PR cria duas actions:

- **github-pages:** Executada para novos commits (merges feitos) na branch `pelican`, publicando o site no GitHub Pages.
- **build-test:** Executa para qualquer outra branch, testando o build do novo artigo.

## Configuração necessária

Antes de fazer o merge desse PR é necessário configurar o repositório para utilizar o deploy do GitHub Pages via Actions, isso pode ser feito em `Settings -> Pages -> Build and deployment -> Source` e definir para `GitHub Actions`, assim ao fazer o merge a action de deploy será executada.